### PR TITLE
removes warnings for "undefined variable" and deprecation on "validate_bool"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+## UNRELEASED
+### Changed
+* `CONFIG.type` is now set to "aio" for nodesets using the AllInOne Installer ("Puppet Collections")
+
+### Removed
+* surplus code has been removed from spec files
+
+### Fixed
+* internal variable `$_securitycheck` (used in `secc_snmpd::config::v2` and `secc_snmpd::config::v3` ) no longer throws "undefined variable" warnings
+* "validate()" commands in init.pp are now different for Puppet 3 / Puppet 4, because the threw deprecation warnings on Puppet 4

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,7 +65,7 @@ class secc_snmpd::config {
         loglevel => 'warning',
       }
   }
-  
+
   if $::secc_snmpd::trap_enabled {
     file { '/etc/snmp/snmptrapd.conf':
       ensure  => present,

--- a/manifests/config/v2.pp
+++ b/manifests/config/v2.pp
@@ -9,9 +9,7 @@ define secc_snmpd::config::v2 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
   # verification password composition
@@ -20,12 +18,10 @@ define secc_snmpd::config::v2 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
-  if $_securitycheck == false and $::secc_snmpd::enforce_password_security == true {
+  if defined('$_securitycheck') and $_securitycheck and $::secc_snmpd::enforce_password_security {
     notify {'Security parameters for Community not met, not configuring community!':
       loglevel => err,
     }

--- a/manifests/config/v3.pp
+++ b/manifests/config/v3.pp
@@ -9,9 +9,7 @@ define secc_snmpd::config::v3 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
   # verification password composition
@@ -20,9 +18,7 @@ define secc_snmpd::config::v3 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
   # verification passphrase length
@@ -31,9 +27,7 @@ define secc_snmpd::config::v3 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
   # verification passphrase composition
@@ -42,9 +36,7 @@ define secc_snmpd::config::v3 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
   if $v3_password == $v3_passphrase {
@@ -52,12 +44,10 @@ define secc_snmpd::config::v3 (
       loglevel => warning,
     }
 
-    if $_securitycheck == undef {
-      $_securitycheck = false
-    }
+    unless defined('$_securitycheck') { $_securitycheck = true }
   }
 
-  if $_securitycheck == false and $::secc_snmpd::enforce_password_security == true {
+  if defined('$_securitycheck') and $_securitycheck and $::secc_snmpd::enforce_password_security {
     notify {'Security parameters for Password or Passphrase not met, not configuring user!':
       loglevel => err,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,19 @@ class secc_snmpd (
   $dlmod_enabled             = $::secc_snmpd::params::dlmod_enabled,
 ) inherits secc_snmpd::params {
 
-  validate_bool($::secc_snmpd::v2_enabled)
+  # true if $::puppetversion < '4.0.0'
+  if versioncmp($::puppetversion, '4.0.0') < 0 {
+    validate_bool($::secc_snmpd::v2_enabled)
+    validate_bool($::secc_snmpd::v3_enabled)
+    validate_bool($::secc_snmpd::enforce_password_security)
+    validate_bool($::secc_snmpd::dlmod_enabled)
+} else {
+    validate_legacy('Boolean', 'validate_bool', $::secc_snmpd::v2_enabled)
+    validate_legacy('Boolean', 'validate_bool', $::secc_snmpd::v3_enabled)
+    validate_legacy('Boolean', 'validate_bool', $::secc_snmpd::enforce_password_security)
+    validate_legacy('Boolean', 'validate_bool', $::secc_snmpd::dlmod_enabled)
+  }
+
   if $::secc_snmpd::v2_enabled {
     # Req1: warning if v2 enabled
     notify {'use of SNMPv2 is not recommended!':
@@ -35,7 +47,6 @@ class secc_snmpd (
     }
   }
 
-  validate_bool($::secc_snmpd::v3_enabled)
   if $::secc_snmpd::v3_enabled {
     if $::secc_snmpd::v3_user == undef {
       fail('v3_user is needed')
@@ -47,10 +58,6 @@ class secc_snmpd (
       fail('v3_passphrase is needed')
     }
   }
-
-  validate_bool($::secc_snmpd::enforce_password_security)
-
-  validate_bool($::secc_snmpd::dlmod_enabled)
 
   contain secc_snmpd::install
 

--- a/spec/acceptance/nodesets/docker-centos6-pc1.yml
+++ b/spec/acceptance/nodesets/docker-centos6-pc1.yml
@@ -7,11 +7,5 @@ HOSTS:
     image: centos:6
     docker_cmd: '["/sbin/init"]'
     docker_preserve_image: true
-    docker_image_commands:
-      - 'yum localinstall -y https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm'
-      - 'yum install -y puppet-agent'
-      - 'source /etc/profile.d/puppet-agent.sh'
-      - '/opt/puppetlabs/puppet/bin/puppet module install puppetlabs-stdlib'
-      - '/opt/puppetlabs/puppet/bin/puppet module install puppetlabs-concat'
 CONFIG:
-  type: foss
+  type: aio

--- a/spec/acceptance/nodesets/docker-centos7-pc1.yml
+++ b/spec/acceptance/nodesets/docker-centos7-pc1.yml
@@ -7,11 +7,5 @@ HOSTS:
     image: centos:7
     docker_cmd: '["/sbin/init"]'
     docker_preserve_image: true
-    docker_image_commands:
-      - 'yum localinstall -y https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
-      - 'yum install -y puppet-agent'
-      - 'source /etc/profile.d/puppet-agent.sh'
-      - '/opt/puppetlabs/puppet/bin/puppet module install puppetlabs-stdlib'
-      - '/opt/puppetlabs/puppet/bin/puppet module install puppetlabs-concat'
 CONFIG:
-  type: foss
+  type: aio

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,16 +13,9 @@ RSpec.configure do |c|
   c.before :suite do
     # Install module to all hosts
     hosts.each do |host|
-
       install_puppet_on(host)
 
-      result = on(host, "puppet config print modulepath")
-      modulepaths = result.stdout.split(":")
-      modulepath = modulepaths[modulepaths.length - 1]
-      logger.info('modulepath: ' + modulepath)
-
-      install_dev_puppet_module_on(host, :source => module_root, :module_name => 'secc_snmpd',
-          :target_module_path => modulepath)
+      install_dev_puppet_module_on(host, :source => module_root, :module_name => 'secc_snmpd',)
       # Install dependencies
       on(host, puppet('module', 'install', 'puppetlabs-stdlib'))
       on(host, puppet('module', 'install', 'puppetlabs-concat'))


### PR DESCRIPTION
* `$_securitycheck` no longer causes "undefined variable warnings
* `validate_bool()` has been replaced by `validate_legacy()` (when using Puppet 4)
* removed that trailing whitespace
* `CONFIG.type` has been set to `aio` for the respective hosts
* some surplus commands have been removed from spec_helper_acceptance and hosts
* a CHANGELOG.md has been added (finally ;))